### PR TITLE
Fixing missing method on ImgCache api

### DIFF
--- a/angular-imgcache.js
+++ b/angular-imgcache.js
@@ -48,11 +48,11 @@ angular.module('ImgCache', [])
             var setImg = function(type, el, src) {
 
                 ImgCache.getCachedFileURL(src, function(src, dest) {
-
+                    var img_src = dest.fullPath.replace('/'. ImgCache.options.localCacheFolder, ImgCache.getCacheFolderURI());
                     if(type === 'bg') {
-                        el.css({'background-image': 'url(' + dest + ')' });
+                        el.css({'background-image': 'url(' + img_src + ')' });
                     } else {
-                        el.attr('src', dest);
+                        el.attr('src', img_src);
                     }
                 });
             }


### PR DESCRIPTION
`ImgCache.getCachedFileURL` doesn't exist on the API anymore. Made a quick fix but not sure if it is the best.