### PR TITLE
Original source fallback handling

### DIFF
--- a/angular-imgcache.js
+++ b/angular-imgcache.js
@@ -68,6 +68,16 @@ angular.module('ImgCache', [])
                         } else {
                             ImgCache.cacheFile(src, function() {
                                 setImg(type, el, src);
+                            },function() {
+                                // fallback to original source if e.g. src is a relative file and therefore loaded from file system
+                                if(src)
+                                {
+                                    if(type === 'bg') {
+                                        el.css({'background-image': 'url(' + src + ')' });
+                                    } else {
+                                        el.attr('src', src);
+                                    }
+                                }
                             });
                         }
 


### PR DESCRIPTION
Added fallback to original source if downloading image file fails for e.g. when file is a local image file on a mobile device.
